### PR TITLE
Do the 'file extension' thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ Would output
 jpg
 php
 ```
+Or just use basic GNU tools (might require slightly differently options on BSD/Mac), some examples I needed recently:
+  ```
+$ find . -type f -printf '%f\n' | grep -Eo '\.[^.]$' | sort | uniq -c | sort -n
+     82 .mid
+    267 .m4a
+    567 .ogg
+    575 .opus
+   3392 .aac
+$ find . -type f -printf '%f\n' | grep -Eo '\.[^.]$' | sort -u
+.aac
+.m4a
+.mid
+.ogg
+.opus
+```
 
 - A command-line program that generates a random string that is N characters long.
 i.e.


### PR DESCRIPTION
Technicalities:
- *very* unusual filenames (e.g., those including a newline or other control characters)
  might break this
- 'filename extension' is not well-defined, so I did some interpretation
- if you absolutely cannot stand the leading dot, just run it through sed -e 's/^.//'
  at the end (note that technically this expression removes the first character
  of each line, regardless of whether it's a dot or not.  However, this does not
  matter here.)

Btw, there's a command-line tool called [`pwgen`](http://explainshell.com/explain/1/pwgen), so if you were trying to generate a password or something, just do:
```
$ pwgen -s 20 1
qYzjaQDuWF7f7PssX1fT
```